### PR TITLE
Add get intial and final month dynamically

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6762,6 +6762,11 @@
         "minimist": "^1.2.5"
       }
     },
+    "moment": {
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
+      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
+    },
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "expo-location": "~8.2.1",
     "expo-notifications": "~0.3.3",
     "expo-status-bar": "^1.0.2",
+    "moment": "^2.29.1",
     "react": "~16.11.0",
     "react-dom": "~16.11.0",
     "react-native": "https://github.com/expo/react-native/archive/sdk-38.0.2.tar.gz",

--- a/src/screens/Home/index.tsx
+++ b/src/screens/Home/index.tsx
@@ -7,6 +7,7 @@ import {
 } from "@react-navigation/native";
 import * as Font from "expo-font";
 import * as Location from "expo-location";
+import moment from "moment";
 import React, { useCallback, useState, useEffect } from "react";
 import { View } from "react-native";
 import { MapEvent } from "react-native-maps";
@@ -140,10 +141,10 @@ const Home: React.FC = () => {
     }, []);
 
     const getInitialAndFinalMonth = () => {
-        const date = new Date();
+        const date = moment();
 
-        const month = date.getMonth() + 1;
-        const year = date.getFullYear();
+        const year = date.year();
+        const month = date.add(-2, "M").month() + 1;
 
         setFinalMonth(month + "/" + year);
         setInitialMonth(month + "/" + (year - 1));

--- a/src/screens/Home/index.tsx
+++ b/src/screens/Home/index.tsx
@@ -141,10 +141,10 @@ const Home: React.FC = () => {
     }, []);
 
     const getInitialAndFinalMonth = () => {
-        const date = moment();
+        const date = moment().subtract(2, "M");
 
         const year = date.year();
-        const month = date.add(-2, "M").month() + 1;
+        const month = date.month() + 1;
 
         setFinalMonth(month + "/" + year);
         setInitialMonth(month + "/" + (year - 1));

--- a/src/screens/Home/index.tsx
+++ b/src/screens/Home/index.tsx
@@ -552,9 +552,10 @@ const Home: React.FC = () => {
                         <InfoSubText style={{ marginBottom: 10 }}>
                             * Casos anuais por 100.000 habitantes
                         </InfoSubText>
-                        <InfoSubText>
+                        <InfoSubText style={{ marginBottom: 10 }}>
                             {`* Dados adquiridos da Secretaria de Segurança Pública - ${selectedUf.toUpperCase()}`}
                         </InfoSubText>
+                        <InfoSubText>{`* ${initialMonth} - ${finalMonth}`}</InfoSubText>
                     </View>
                 </InfoModal>
             )}

--- a/src/screens/Home/index.tsx
+++ b/src/screens/Home/index.tsx
@@ -87,6 +87,9 @@ const Home: React.FC = () => {
     const route = useRoute<RouteProp<ParamList, "params">>();
     const navigation = useNavigation();
 
+    const [initialMonth, setInitialMonth] = useState("");
+    const [finalMonth, setFinalMonth] = useState("");
+
     const [isModalOpen, setIsModalOpen] = useState(false);
     const [isReporting, setIsReporting] = useState(false);
     const [isPlaceModalOpen, setIsPlaceModalOpen] = useState(false);
@@ -133,7 +136,18 @@ const Home: React.FC = () => {
 
     useEffect(() => {
         getCurrentLocation();
+        getInitialAndFinalMonth();
     }, []);
+
+    const getInitialAndFinalMonth = () => {
+        const date = new Date();
+
+        const month = date.getMonth() + 1;
+        const year = date.getFullYear();
+
+        setFinalMonth(month + "/" + year);
+        setInitialMonth(month + "/" + (year - 1));
+    };
 
     const getCurrentLocation = async () => {
         const { status } = await Location.requestPermissionsAsync();
@@ -189,8 +203,8 @@ const Home: React.FC = () => {
             const response = await getOccurrencesByCrimeNature(
                 selectedUf,
                 option.label,
-                "1/2020",
-                "12/2020",
+                initialMonth,
+                finalMonth,
                 1
             );
 

--- a/src/screens/Occurrence/index.tsx
+++ b/src/screens/Occurrence/index.tsx
@@ -206,10 +206,10 @@ const Occurrence: React.FC = () => {
                 setIsLoading(true);
                 const response = isEditing
                     ? await updateOccurrence(
-                        idOccurrence,
-                        data.token,
-                        dataOccurrence
-                    )
+                          idOccurrence,
+                          data.token,
+                          dataOccurrence
+                      )
                     : await createOccurrence(dataOccurrence, data.token);
 
                 if (!response.body.error && response.status === 201) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5169,6 +5169,11 @@ mkdirp@^0.5.1, mkdirp@~0.5.1:
   dependencies:
     minimist "^1.2.5"
 
+moment@^2.29.1:
+  version "2.29.1"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"
+  integrity sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==
+
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue 
Resolves #90 
<!-- Link the pull request's respective issue -->

## Description
Make the initial and final month dynamical get from now to one year ago.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.


## How to validate?
Check the code and make sure dates are getting dinamically.
