### PR TITLE
Adds validation to specific neighborhoods' ratings

### DIFF
--- a/src/screens/Rating/index.tsx
+++ b/src/screens/Rating/index.tsx
@@ -21,6 +21,7 @@ import {
     Detail,
     DetailLabel,
     DetailContainer,
+    TumbsContainer,
     ImpressionContainer,
 } from "./styles";
 
@@ -238,34 +239,40 @@ const Rating: React.FC = () => {
                             <Detail style={{ elevation: 3 }}>
                                 <DetailLabel>{detail.label}</DetailLabel>
                             </Detail>
-                            <ImpressionContainer
+                            <TumbsContainer>
+                                {stars > 1 && (
+                                <ImpressionContainer
                                 color={theme.primaryImpressionGreen}
                                 select={detail.like}
                                 style={{ elevation: 3 }}
-                            >
-                                <AntDesign
-                                    name="like2"
-                                    size={scale(25)}
-                                    color={theme.primarySuperDarkBlue}
-                                    onPress={() =>
-                                        handleDetail(detail.value, "like")
-                                    }
-                                />
-                            </ImpressionContainer>
-                            <ImpressionContainer
-                                select={detail.dislike}
-                                color={theme.primaryRed}
-                                style={{ elevation: 3 }}
-                            >
-                                <AntDesign
-                                    name="dislike2"
-                                    size={scale(25)}
-                                    color={theme.primarySuperDarkBlue}
-                                    onPress={() =>
-                                        handleDetail(detail.value, "dislike")
-                                    }
-                                />
-                            </ImpressionContainer>
+                                >
+                                    <AntDesign
+                                        name="like2"
+                                        size={scale(25)}
+                                        color={theme.primarySuperDarkBlue}
+                                        onPress={() =>
+                                            handleDetail(detail.value, "like")
+                                        }
+                                    />
+                                </ImpressionContainer>
+                                )}
+                                {stars < 5 && (
+                                    <ImpressionContainer
+                                    select={detail.dislike}
+                                    color={theme.primaryRed}
+                                    style={{ elevation: 3 }}
+                                    >
+                                    <AntDesign
+                                        name="dislike2"
+                                        size={scale(25)}
+                                        color={theme.primarySuperDarkBlue}
+                                        onPress={() =>
+                                            handleDetail(detail.value, "dislike")
+                                        }
+                                        />
+                                </ImpressionContainer>
+                                )}
+                            </TumbsContainer>
                         </DetailContainer>
                     );
                 })}

--- a/src/screens/Rating/styles.ts
+++ b/src/screens/Rating/styles.ts
@@ -45,8 +45,14 @@ export const DetailContainer = styled.View`
     justify-content: space-between;
     align-items: center;
     flex-direction: row;
-
     margin-bottom: ${scale(15)}px;
+`;
+
+export const TumbsContainer = styled.View`
+    flex-direction: row;
+    justify-content: center;
+    width: 40%;
+    margin-left: ${scale(7)}px; 
 `;
 
 export const Detail = styled.View`
@@ -80,4 +86,5 @@ export const ImpressionContainer = styled(RectButton).attrs((props) => ({
         css`
             opacity: 0.7;
         `};
+    margin: ${scale(7)}px;
 `;


### PR DESCRIPTION
Co-authored-by: Brenda <brendasantosv.bs@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Issue 
Resolves #98 
<!-- Link the pull request's respective issue -->

## Description
This PR created a validation when the user is rating a neighborhood. The validation is specified in the issue above. The way it works is that it only render the tumb (up or down) if it is supposed to based on the numbers of stars given.
<!--- Describe your changes in detail -->

## Screenshots (if appropriate):
![WhatsApp Image 2020-11-27 at 20 20 50](https://user-images.githubusercontent.com/31369018/100488770-f5419e00-30ee-11eb-8a9d-28aa786aba53.jpeg)
![WhatsApp Image 2020-11-27 at 20 20 50 (1)](https://user-images.githubusercontent.com/31369018/100488777-fc68ac00-30ee-11eb-9dec-25b2c22c9882.jpeg)
![WhatsApp Image 2020-11-27 at 20 20 50 (2)](https://user-images.githubusercontent.com/31369018/100488778-fd014280-30ee-11eb-909e-fa2b03831ad6.jpeg)


<!--- You may want to show a new page functionality, for example -->
<!--- If not appropriate, just delete this topic -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

## How to validate?
Try to validate a negative rating with a 5 star review. and see that it fails.
Try to validate a positive rating with a 1 star review and see that it fails.
See that the user can validate with positive/negative review when the number of stars is between 2 and 4 inclusive.


<!--- Give tips on how the reviewer of this PR does to validate what was done? (not always obvious) -->
